### PR TITLE
Feature: generify dynamic JPA query templates by creating a main abstraction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,6 @@ ext {
     versions = [
             'spring-boot.version'           : '2.7.0',
             'spring-framework.version'      : '5.3.20',
-            'spring-dynamic-commons.version': '1.0.0',
             'jakarta-transaction.version'   : '1.3.3',
             'jakarta-persistence.version'   : '2.2.3',
             'hibernate.version'             : '5.6.9.Final',
@@ -43,7 +42,6 @@ ext {
             'org.springframework:spring-context-support'  : 'spring-framework.version',
             'org.springframework.data:spring-data-commons': 'spring-boot.version',
             'org.springframework.data:spring-data-jpa'    : 'spring-boot.version',
-            'com.github.joutvhu:spring-dynamic-commons'   : 'spring-dynamic-commons.version',
             'jakarta.transaction:jakarta.transaction-api' : 'jakarta-transaction.version',
             'jakarta.persistence:jakarta.persistence-api' : 'jakarta-persistence.version',
             'org.hibernate:hibernate-core'                : 'hibernate.version',
@@ -71,10 +69,11 @@ dependencies {
     implementation 'org.springframework.data:spring-data-jpa'
     implementation 'org.springframework.data:spring-data-commons'
 
-    implementation 'com.github.joutvhu:spring-dynamic-commons'
-
     implementation 'jakarta.transaction:jakarta.transaction-api'
     implementation 'jakarta.persistence:jakarta.persistence-api'
+
+    implementation 'org.freemarker:freemarker'
+    implementation 'org.apache.commons:commons-lang3'
 
     implementation('org.hibernate:hibernate-core') {
         exclude group: 'javax.activation', module: 'javax.activation-api'

--- a/src/main/java/com/joutvhu/dynamic/commons/freemarker/FreemarkerDynamicQueryTemplate.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/freemarker/FreemarkerDynamicQueryTemplate.java
@@ -1,0 +1,15 @@
+package com.joutvhu.dynamic.commons.freemarker;
+
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplate;
+import freemarker.template.Template;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class FreemarkerDynamicQueryTemplate implements DynamicQueryTemplate<Template> {
+    private final Template template;
+
+    @Override
+    public Template getTemplate() {
+        return this.template;
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/freemarker/FreemarkerDynamicQueryTemplateHandler.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/freemarker/FreemarkerDynamicQueryTemplateHandler.java
@@ -1,0 +1,133 @@
+package com.joutvhu.dynamic.commons.freemarker;
+
+import com.joutvhu.dynamic.commons.util.DynamicTemplateResolver;
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplate;
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplateHandler;
+import freemarker.cache.StringTemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.context.ResourceLoaderAware;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.stereotype.Component;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * DynamicQueryTemplates
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+@NoArgsConstructor
+@Component
+public class FreemarkerDynamicQueryTemplateHandler implements
+        DynamicQueryTemplateHandler<Template>,
+        ResourceLoaderAware,
+        InitializingBean {
+
+    private static final Log log = LogFactory.getLog(FreemarkerDynamicQueryTemplateHandler.class);
+
+    private static StringTemplateLoader sqlTemplateLoader = new StringTemplateLoader();
+    private static Configuration cfg = FreemarkerTemplateConfiguration.instanceWithDefault()
+            .templateLoader(sqlTemplateLoader)
+            .configuration();
+
+    private String encoding = "UTF-8";
+    private String templateLocation = "classpath:/query";
+    private String suffix = ".dsql";
+    private ResourceLoader resourceLoader;
+
+    @Override
+    public DynamicQueryTemplate<Template> createTemplate(String name, String content) {
+        try {
+            return new FreemarkerDynamicQueryTemplate(new Template(name, content, cfg));
+        } catch (IOException e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    @Override
+    public DynamicQueryTemplate<Template> findTemplate(String name) {
+        try {
+            Template template = cfg.getTemplate(name, encoding);
+            return new FreemarkerDynamicQueryTemplate(template);
+        } catch (IOException e) {
+            log.error("Failed finding template: " + name, e);
+            return null;
+        }
+    }
+
+    @Override
+    @SneakyThrows
+    public String processTemplate(DynamicQueryTemplate<Template> template, Map<String, Object> params) {
+        return FreeMarkerTemplateUtils.processTemplateIntoString(template.getTemplate(), params);
+    }
+
+
+    /**
+     * Setup encoding for the process of reading the query template files.
+     *
+     * @param encoding of query template file, default is "UTF-8"
+     */
+    public void setEncoding(String encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Specify the location of the query template files.
+     *
+     * @param templateLocation is location of the query template files, default is "classpath:/query"
+     */
+    public void setTemplateLocation(String templateLocation) {
+        this.templateLocation = templateLocation;
+    }
+
+    /**
+     * Specify filename extension of the query template files.
+     *
+     * @param suffix is filename extension of the query template files, default is ".dsql"
+     */
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
+
+    /**
+     * Specify {@link ResourceLoader} to load the query template files.
+     */
+    @Override
+    public void setResourceLoader(ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        String pattern;
+        if (StringUtils.isNotBlank(templateLocation))
+            pattern = templateLocation.contains(suffix) ? templateLocation : templateLocation + "/**/*" + suffix;
+        else pattern = "classpath:/**/*" + suffix;
+
+        PathMatchingResourcePatternResolver resourcePatternResolver =
+                new PathMatchingResourcePatternResolver(resourceLoader);
+        Resource[] resources = resourcePatternResolver.getResources(pattern);
+
+        for (Resource resource : resources) {
+            DynamicTemplateResolver.of(resource).encoding(encoding).load((templateName, content) -> {
+                Object src = sqlTemplateLoader.findTemplateSource(templateName);
+                if (src != null)
+                    log.warn("Found duplicate template key, will replace the value, key: " + templateName);
+                sqlTemplateLoader.putTemplate(templateName, content);
+            });
+        }
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/freemarker/FreemarkerTemplateConfiguration.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/freemarker/FreemarkerTemplateConfiguration.java
@@ -1,0 +1,49 @@
+package com.joutvhu.dynamic.commons.freemarker;
+
+import com.joutvhu.dynamic.commons.freemarker.directive.SetDirective;
+import com.joutvhu.dynamic.commons.freemarker.directive.TrimDirective;
+import com.joutvhu.dynamic.commons.freemarker.directive.WhereDirective;
+import freemarker.cache.TemplateLoader;
+import freemarker.template.Configuration;
+
+/**
+ * Freemarker configuration builder.
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+public class FreemarkerTemplateConfiguration {
+    private Configuration cfg;
+
+    protected FreemarkerTemplateConfiguration() {
+        this.cfg = new Configuration(Configuration.DEFAULT_INCOMPATIBLE_IMPROVEMENTS);
+    }
+
+    public static FreemarkerTemplateConfiguration instance() {
+        return new FreemarkerTemplateConfiguration();
+    }
+
+    public static FreemarkerTemplateConfiguration instanceWithDefault() {
+        return instance().applyDefault();
+    }
+
+    public FreemarkerTemplateConfiguration applyDefault() {
+        cfg.setTagSyntax(Configuration.ANGLE_BRACKET_TAG_SYNTAX);
+        cfg.setInterpolationSyntax(Configuration.DOLLAR_INTERPOLATION_SYNTAX);
+
+        cfg.setSharedVariable("trim", new TrimDirective());
+        cfg.setSharedVariable("set", new SetDirective());
+        cfg.setSharedVariable("where", new WhereDirective());
+
+        return this;
+    }
+
+    public FreemarkerTemplateConfiguration templateLoader(TemplateLoader templateLoader) {
+        cfg.setTemplateLoader(templateLoader);
+        return this;
+    }
+
+    public Configuration configuration() {
+        return cfg;
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/freemarker/directive/SetDirective.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/freemarker/directive/SetDirective.java
@@ -1,0 +1,32 @@
+package com.joutvhu.dynamic.commons.freemarker.directive;
+
+import freemarker.core.Environment;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * The set directive knows to only insert "SET" if there is any content returned by the containing tags,
+ * If that content begins or ends with ",", it knows to strip it off.
+ * They are used in templates like {@code <@set>...</@set>}
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+public class SetDirective implements TemplateDirectiveModel {
+    private static final TrimDirective.TrimSymbol symbols = new TrimDirective.TrimSymbol("set", null, ",");
+
+    @Override
+    public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body) throws TemplateException, IOException {
+        if (!params.isEmpty())
+            throw new TemplateModelException("This directive doesn't allow parameters.");
+
+        if (body != null)
+            TrimDirective.TrimWriter.of(env.getOut(), symbols).render(body);
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/freemarker/directive/TrimDirective.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/freemarker/directive/TrimDirective.java
@@ -1,0 +1,185 @@
+package com.joutvhu.dynamic.commons.freemarker.directive;
+
+import freemarker.core.Environment;
+import freemarker.ext.beans.InvalidPropertyException;
+import freemarker.template.SimpleScalar;
+import freemarker.template.SimpleSequence;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * The trim directive knows to only insert the prefix and suffix if there is any content returned by the containing tags
+ * And the trim directive will remove prefixOverrides and suffixOverrides in the content
+ * They are used in templates like {@code <@trim prefix="where (" prefixOverrides=["and ", "or "] suffix=")" suffixOverrides=[" and", " or"]>...</@trim>}
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+public class TrimDirective implements TemplateDirectiveModel {
+    @Override
+    public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body) throws TemplateException, IOException {
+        TrimSymbol symbols = new TrimSymbol(params);
+        if (body != null)
+            TrimWriter.of(env.getOut(), symbols).render(body);
+    }
+
+    /**
+     * Trim directive writer
+     */
+    public static class TrimWriter extends Writer {
+        private final Writer out;
+        private final TrimSymbol symbols;
+        private final StringBuilder contentBuilder = new StringBuilder();
+
+        public static TrimWriter of(Writer out, TrimSymbol symbols) {
+            return new TrimWriter(out, symbols);
+        }
+
+        public TrimWriter(Writer out, TrimSymbol symbols) {
+            this.out = out;
+            this.symbols = symbols;
+        }
+
+        @Override
+        public void write(char[] cbuf, int off, int len) throws IOException {
+            String content = String.copyValueOf(cbuf);
+            this.contentBuilder.append(content);
+        }
+
+        public void afterWrite() throws IOException {
+            String content = this.contentBuilder.toString();
+
+            for (String prefix : symbols.prefixOverrides)
+                content = Pattern.compile("^[ \\t\\n]*" + escapeRegular(prefix), Pattern.CASE_INSENSITIVE)
+                        .matcher(content)
+                        .replaceAll("");
+            for (String suffix : symbols.suffixOverrides)
+                content = Pattern.compile(escapeRegular(suffix) + "[ \\t\\n]*$", Pattern.CASE_INSENSITIVE)
+                        .matcher(content)
+                        .replaceAll("");
+
+            content = content.trim();
+            if (!content.isEmpty()) {
+                if (symbols.prefix != null)
+                    content = symbols.prefix + " " + content;
+                if (symbols.suffix != null)
+                    content = content + " " + symbols.suffix;
+            }
+            content = " " + content + " ";
+
+            out.write(content);
+        }
+
+        public void render(TemplateDirectiveBody body) throws IOException, TemplateException {
+            body.render(this);
+            this.afterWrite();
+        }
+
+        private String escapeRegular(String regex) {
+            return Pattern.compile("([-/\\\\^$*+?.()|\\[\\]{}])").matcher(regex).replaceAll("\\\\$1");
+        }
+
+        @Override
+        public void flush() throws IOException {
+            out.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            out.close();
+        }
+    }
+
+    /**
+     * Trim directive param container
+     */
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class TrimSymbol {
+        private String prefix;
+        private List<String> prefixOverrides;
+        private String suffix;
+        private List<String> suffixOverrides;
+
+        public TrimSymbol(String prefix, String suffix, String... overrides) {
+            this.prefix = prefix;
+            this.suffix = suffix;
+
+            List<String> listOverrides = new ArrayList<>();
+            Collections.addAll(listOverrides, overrides);
+            this.prefixOverrides = listOverrides;
+            this.suffixOverrides = listOverrides;
+        }
+
+        /**
+         * Get params of trim directive from params map
+         *
+         * @param params map
+         * @throws TemplateException if invalid params
+         */
+        public TrimSymbol(Map<String, Object> params) throws TemplateException {
+            this.prefix = getStringParam(params, "prefix");
+            this.prefixOverrides = getListParam(params, "prefixOverrides");
+            this.suffix = getStringParam(params, "suffix");
+            this.suffixOverrides = getListParam(params, "suffixOverrides");
+
+            if (prefix == null && prefixOverrides.isEmpty() && suffix == null && suffixOverrides.isEmpty())
+                throw new TemplateModelException("The trim directive requires at least one of the following parameters: " +
+                        "prefix, prefixOverrides, suffix, suffixOverrides");
+        }
+
+        private String getStringParam(Map<String, Object> params, String name) throws TemplateException {
+            if (params.containsKey(name)) {
+                Object param = params.get(name);
+                if (param instanceof SimpleScalar)
+                    return getStringFromSimpleScalar((SimpleScalar) param, name);
+            }
+            return null;
+        }
+
+        private String getStringFromSimpleScalar(SimpleScalar simpleScalar, String name) throws TemplateException {
+            String value = simpleScalar.getAsString();
+            if (value != null && !value.trim().isEmpty())
+                return value;
+            else throw new InvalidPropertyException("The " + name + " param cannot be empty string or spaces.");
+        }
+
+        private List<String> getListParam(Map<String, Object> params, String name) throws TemplateException {
+            List<String> result = new ArrayList<>();
+            if (params.containsKey(name)) {
+                Object param = params.get(name);
+                if (param instanceof SimpleScalar)
+                    result.add(getStringFromSimpleScalar((SimpleScalar) param, name));
+                else if (param instanceof SimpleSequence)
+                    return getListFromSimpleSequence((SimpleSequence) param, name);
+            }
+            return result;
+        }
+
+        private List<String> getListFromSimpleSequence(SimpleSequence simpleSequence, String name) throws TemplateException {
+            List<String> result = new ArrayList<>();
+            for (int i = 0, len = simpleSequence.size(); i < len; i++) {
+                String value = simpleSequence.get(i).toString();
+                if (value != null && !value.trim().isEmpty())
+                    result.add(value);
+                else throw new InvalidPropertyException("The " + name + " param cannot be contains empty or spaces.");
+            }
+            return result;
+        }
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/freemarker/directive/WhereDirective.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/freemarker/directive/WhereDirective.java
@@ -1,0 +1,47 @@
+package com.joutvhu.dynamic.commons.freemarker.directive;
+
+import freemarker.core.Environment;
+import freemarker.template.TemplateDirectiveBody;
+import freemarker.template.TemplateDirectiveModel;
+import freemarker.template.TemplateException;
+import freemarker.template.TemplateModel;
+import freemarker.template.TemplateModelException;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The where directive knows to only insert "WHERE" if there is any content returned by the containing tags,
+ * If that content begins or ends with "AND" or "OR", it knows to strip it off.
+ * They are used in templates like {@code <@where>...</@where>}
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+public class WhereDirective implements TemplateDirectiveModel {
+    private static final TrimDirective.TrimSymbol symbols = new TrimDirective.TrimSymbol(
+            "where", getOverrides(true, "and", "or"),
+            null, getOverrides(false, "and", "or"));
+
+    private static final List<String> getOverrides(boolean prefix, String... overrides) {
+        List<String> result = new ArrayList<>();
+        for (String o : overrides) {
+            result.add(prefix ? o + " " : " " + o);
+            result.add(prefix ? o + "\n" : "\n" + o);
+            result.add(prefix ? o + "\t" : "\t" + o);
+        }
+        return result;
+    }
+
+    @Override
+    public void execute(Environment env, Map params, TemplateModel[] loopVars, TemplateDirectiveBody body)
+            throws TemplateException, IOException {
+        if (!params.isEmpty())
+            throw new TemplateModelException("This directive doesn't allow parameters.");
+
+        if (body != null)
+            TrimDirective.TrimWriter.of(env.getOut(), symbols).render(body);
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/util/ApplicationContextHolder.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/util/ApplicationContextHolder.java
@@ -1,0 +1,25 @@
+package com.joutvhu.dynamic.commons.util;
+
+import lombok.experimental.UtilityClass;
+import org.springframework.context.ApplicationContext;
+
+import java.util.Collection;
+
+/**
+ * Help call method of {@link ApplicationContext} from any class.
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+@UtilityClass
+public class ApplicationContextHolder {
+    public ApplicationContext appContext;
+
+    public <T> Collection<T> getBeansOfType(Class<T> clazz) {
+        return appContext.getBeansOfType(clazz).values();
+    }
+
+    public <T> T getBean(Class<T> clazz) {
+        return appContext.getBean(clazz);
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/util/DynamicTemplateResolver.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/util/DynamicTemplateResolver.java
@@ -1,0 +1,92 @@
+package com.joutvhu.dynamic.commons.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.core.io.Resource;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Read and parse template query files into query templates
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+public class DynamicTemplateResolver {
+    private final Resource resource;
+    private List<String> lines;
+    private String encoding = "UTF-8";
+
+    public DynamicTemplateResolver(Resource resource) {
+        this.resource = resource;
+    }
+
+    public static DynamicTemplateResolver of(Resource resource) {
+        return new DynamicTemplateResolver(resource);
+    }
+
+    public static BufferedReader toBufferedReader(Reader reader) {
+        return reader instanceof BufferedReader ? (BufferedReader) reader : new BufferedReader(reader);
+    }
+
+    public static List<String> readLines(InputStream input, String encoding) throws IOException {
+        BufferedReader reader = toBufferedReader(new InputStreamReader(input,
+                encoding == null ? Charset.defaultCharset() : Charset.forName(encoding)));
+        List<String> list = new ArrayList<>();
+
+        for (String line = reader.readLine(); line != null; line = reader.readLine()) {
+            list.add(line);
+        }
+
+        return list;
+    }
+
+    public DynamicTemplateResolver encoding(String encoding) {
+        this.encoding = encoding;
+        return this;
+    }
+
+    private boolean isNameLine(String line) {
+        return StringUtils.startsWith(line, "--");
+    }
+
+    private boolean isNameLine(int index) {
+        return isNameLine(lines.get(index));
+    }
+
+    public void load(NamedTemplateCallback callback) throws Exception {
+        InputStream inputStream = resource.getInputStream();
+        lines = DynamicTemplateResolver.readLines(inputStream, encoding);
+
+        int index = 0;
+        String name = null;
+        int total = lines.size();
+        StringBuilder content = new StringBuilder();
+
+        while (index < total) {
+            do {
+                String line = lines.get(index);
+                if (isNameLine(line))
+                    name = StringUtils.trim(StringUtils.substring(line, 2));
+                else {
+                    line = StringUtils.trimToNull(line);
+                    if (line != null)
+                        content.append(line).append(" ");
+                }
+                index++;
+            } while (index < total && !isNameLine(index));
+
+            // Next template
+            if (name != null)
+                callback.process(name, content.toString());
+            name = null;
+            content = new StringBuilder();
+        }
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/commons/util/NamedTemplateCallback.java
+++ b/src/main/java/com/joutvhu/dynamic/commons/util/NamedTemplateCallback.java
@@ -1,0 +1,11 @@
+package com.joutvhu.dynamic.commons.util;
+
+/**
+ * Callback when found a query template {@link freemarker.template.Template}
+ *
+ * @author Giao Ho
+ * @since 1.0.0
+ */
+public interface NamedTemplateCallback {
+    void process(String templateName, String content);
+}

--- a/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplate.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplate.java
@@ -1,0 +1,5 @@
+package com.joutvhu.dynamic.jpa;
+
+public interface DynamicQueryTemplate<T> {
+    T getTemplate();
+}

--- a/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplateHandler.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplateHandler.java
@@ -1,0 +1,4 @@
+package com.joutvhu.dynamic.jpa;
+
+public interface DynamicQueryTemplateHandler<T> extends DynamicQueryTemplateProvider<T>, DynamicQueryTemplateProcessor<T> {
+}

--- a/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplateProcessor.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplateProcessor.java
@@ -1,0 +1,7 @@
+package com.joutvhu.dynamic.jpa;
+
+import java.util.Map;
+
+public interface DynamicQueryTemplateProcessor<T> {
+    String processTemplate(DynamicQueryTemplate<T> template, Map<String, Object> params);
+}

--- a/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplateProvider.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/DynamicQueryTemplateProvider.java
@@ -1,0 +1,6 @@
+package com.joutvhu.dynamic.jpa;
+
+public interface DynamicQueryTemplateProvider<T> {
+    DynamicQueryTemplate<T> createTemplate(String name, String query);
+    DynamicQueryTemplate<T> findTemplate(String name);
+}

--- a/src/main/java/com/joutvhu/dynamic/jpa/query/DynamicJpaQueryMethod.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/query/DynamicJpaQueryMethod.java
@@ -1,11 +1,9 @@
 package com.joutvhu.dynamic.jpa.query;
 
-import com.joutvhu.dynamic.commons.DynamicQueryTemplates;
-import com.joutvhu.dynamic.commons.util.ApplicationContextHolder;
-import com.joutvhu.dynamic.commons.util.TemplateConfiguration;
 import com.joutvhu.dynamic.jpa.DynamicQuery;
-import freemarker.template.Configuration;
-import freemarker.template.Template;
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplate;
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplateProvider;
+import com.joutvhu.dynamic.commons.util.ApplicationContextHolder;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.data.jpa.provider.QueryExtractor;
@@ -16,7 +14,6 @@ import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.StringUtils;
 
-import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.HashMap;
@@ -30,14 +27,13 @@ import java.util.Map;
  */
 public class DynamicJpaQueryMethod extends JpaQueryMethod {
     private static final Map<String, String> templateMap = new HashMap<>();
-    private static Configuration cfg = TemplateConfiguration.instanceWithDefault().configuration();
 
     private final Method method;
     private final Lazy<Boolean> isNativeQuery;
 
-    private Template queryTemplate;
-    private Template countQueryTemplate;
-    private Template countProjectionTemplate;
+    private DynamicQueryTemplate queryTemplate;
+    private DynamicQueryTemplate countQueryTemplate;
+    private DynamicQueryTemplate countProjectionTemplate;
 
     static {
         templateMap.put("value", "");
@@ -60,21 +56,18 @@ public class DynamicJpaQueryMethod extends JpaQueryMethod {
                 .of(() -> getMergedOrDefaultAnnotationValue("nativeQuery", DynamicQuery.class, Boolean.class));
     }
 
-    protected Template findTemplate(String name) {
-        DynamicQueryTemplates queryTemplates = ApplicationContextHolder.getBean(DynamicQueryTemplates.class);
-        return queryTemplates != null ? queryTemplates.findTemplate(name) : null;
+    protected DynamicQueryTemplate findTemplate(String name) {
+        DynamicQueryTemplateProvider provider = getTemplateProvider();
+        return provider != null ? provider.findTemplate(name) : null;
     }
 
-    protected Template createTemplate(String name, String content) {
-        try {
-            return new Template(name, content, cfg);
-        } catch (IOException e) {
-            e.printStackTrace();
-            return null;
-        }
+    protected DynamicQueryTemplate createTemplate(String name, String query) {
+        DynamicQueryTemplateProvider provider = getTemplateProvider();
+        return provider.createTemplate(name, query);
     }
 
-    protected Template getTemplate(String name) {
+
+    protected DynamicQueryTemplate getTemplate(String name) {
         String templateName = templateMap.get(name);
         if (StringUtils.hasText(templateName)) templateName = "." + templateName;
         templateName = getTemplateKey() + templateName;
@@ -88,24 +81,29 @@ public class DynamicJpaQueryMethod extends JpaQueryMethod {
     }
 
     @Nullable
-    public Template getQueryTemplate() {
+    public DynamicQueryTemplate getQueryTemplate() {
         if (queryTemplate == null)
             queryTemplate = getTemplate("value");
         return queryTemplate;
     }
 
     @Nullable
-    public Template getCountQueryTemplate() {
+    public DynamicQueryTemplate getCountQueryTemplate() {
         if (countQueryTemplate == null)
             countQueryTemplate = getTemplate("countQuery");
         return countQueryTemplate;
     }
 
     @Nullable
-    public Template getCountProjectionTemplate() {
+    public DynamicQueryTemplate getCountProjectionTemplate() {
         if (countProjectionTemplate == null)
             countProjectionTemplate = getTemplate("countProjection");
         return countProjectionTemplate;
+    }
+
+
+    private DynamicQueryTemplateProvider getTemplateProvider() {
+        return ApplicationContextHolder.getBean(DynamicQueryTemplateProvider.class);
     }
 
     private String getEntityName() {

--- a/src/main/java/com/joutvhu/dynamic/jpa/query/DynamicJpaRepositoryQuery.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/query/DynamicJpaRepositoryQuery.java
@@ -1,13 +1,13 @@
 package com.joutvhu.dynamic.jpa.query;
 
-import com.joutvhu.dynamic.jpa.DynamicQuery;
-import freemarker.template.Template;
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplate;
+import com.joutvhu.dynamic.jpa.DynamicQueryTemplateProcessor;
+import com.joutvhu.dynamic.commons.util.ApplicationContextHolder;
 import org.springframework.data.jpa.repository.query.*;
 import org.springframework.data.repository.query.*;
 import org.springframework.data.util.Lazy;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.lang.Nullable;
-import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 
 import javax.persistence.EntityManager;
 import javax.persistence.Query;
@@ -47,16 +47,18 @@ public class DynamicJpaRepositoryQuery extends AbstractJpaQuery {
         this.evaluationContextProvider = evaluationContextProvider;
     }
 
-    protected String buildQuery(Template template, JpaParametersParameterAccessor accessor) {
+    protected String buildQuery(DynamicQueryTemplate template, JpaParametersParameterAccessor accessor) {
         try {
             if (template != null) {
+                DynamicQueryTemplateProcessor processor = ApplicationContextHolder.getBean(DynamicQueryTemplateProcessor.class);
                 Map<String, Object> model = DynamicJpaParameterAccessor.of(accessor).getParamModel();
-                String queryString = FreeMarkerTemplateUtils.processTemplateIntoString(template, model);
-                queryString = queryString
+                String queryString = processor.processTemplate(template, model)
                         .replaceAll("\n", " ")
                         .replaceAll("\t", " ")
                         .replaceAll(" +", " ")
+                        .replaceAll("::", " \\\\:\\\\: ") // postgres cast escaping for hibernate column::text
                         .trim();
+
                 return queryString.isEmpty() ? null : queryString;
             }
         } catch (Exception e) {

--- a/src/test/java/com/joutvhu/dynamic/freemarker/DirectiveTest.java
+++ b/src/test/java/com/joutvhu/dynamic/freemarker/DirectiveTest.java
@@ -1,0 +1,32 @@
+
+package com.joutvhu.dynamic.freemarker;
+
+import com.joutvhu.dynamic.commons.freemarker.FreemarkerTemplateConfiguration;
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+class DirectiveTest {
+    @ParameterizedTest
+    @CsvSource({
+            "'where', '<@where> and (abcd) or</@where>', ' where (abcd) '",
+            "'where', '<@where> \nor\n   abcd  \nand\n </@where>', ' where abcd '",
+            "'where', '<@where> \nOR\n   abcd  \nAND\n </@where>', ' where abcd '",
+            "'set', '<@set> ,abcd, </@set>', ' set abcd '",
+            "'set', '<@set>\n , abcd ,</@set>', ' set abcd '",
+            "'trim', '<@trim prefix=\"69\" prefixOverrides=[\"a\"] suffix=\"e\" suffixOverrides=[\"b\"]> a abcd b</@trim>', ' 69 abcd e '",
+    })
+    void testDirectives(String name, String source, String expected) throws IOException, TemplateException {
+        Configuration cfg = FreemarkerTemplateConfiguration.instanceWithDefault().configuration();
+        Template template = new Template(name, source, cfg);
+        String queryString = FreeMarkerTemplateUtils.processTemplateIntoString(template, new HashMap<>());
+        Assertions.assertEquals(expected, queryString);
+    }
+}

--- a/src/test/java/com/joutvhu/dynamic/jpa/JpaDynamicApplication.java
+++ b/src/test/java/com/joutvhu/dynamic/jpa/JpaDynamicApplication.java
@@ -1,6 +1,6 @@
 package com.joutvhu.dynamic.jpa;
 
-import com.joutvhu.dynamic.commons.DynamicQueryTemplates;
+import com.joutvhu.dynamic.commons.freemarker.FreemarkerDynamicQueryTemplateHandler;
 import com.joutvhu.dynamic.jpa.support.DynamicJpaRepositoryFactoryBean;
 import org.hibernate.cfg.AvailableSettings;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -82,9 +82,9 @@ public class JpaDynamicApplication {
     }
 
     @Bean
-    public DynamicQueryTemplates dynamicQueryTemplates() {
-        DynamicQueryTemplates queryTemplates = new DynamicQueryTemplates();
-        queryTemplates.setSuffix(".dsql");
-        return queryTemplates;
+    public DynamicQueryTemplateHandler dynamicQueryTemplates() {
+        FreemarkerDynamicQueryTemplateHandler templateHandler = new FreemarkerDynamicQueryTemplateHandler();
+        templateHandler.setSuffix(".dsql");
+        return templateHandler;
     }
 }


### PR DESCRIPTION
In order to keep this implementation more flexible, this is an implementation to enable multiple template providers. There's is also minor fix for postgres type casting in queries and a rollback from using commons into the same project.

I just felt like the whole commons was an "over" thing after I have resignified a few things and the commons ended up with 3-4 files, ended up looking like it had no purpose.

This module plus an external module for each template implementation looks like a decent approach for the future.

`com.github.joutvhu:spring-dynamic-jpa`
`com.github.joutvhu:spring-dynamic-jpa-freemarker`
`com.github.joutvhu:spring-dynamic-jpa-handlebars`