### PR TITLE
Feature: improve concurrency and enable freemarker custom configuration

### DIFF
--- a/src/main/java/com/joutvhu/dynamic/jpa/freemarker/ConcurrentStringTemplateLoader.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/freemarker/ConcurrentStringTemplateLoader.java
@@ -1,0 +1,73 @@
+package com.joutvhu.dynamic.jpa.freemarker;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import freemarker.cache.TemplateLoader;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+public class ConcurrentStringTemplateLoader implements TemplateLoader {
+    private final Map<String, StringTemplateSource> templates;
+
+    public ConcurrentStringTemplateLoader() {
+        this.templates = new ConcurrentHashMap<>();
+    }
+
+    public boolean hasTemplateSource(String name) {
+        return templates.containsKey(name);
+    }
+
+    public void putTemplate(String name, String templateSource) {
+        putTemplate(name, templateSource, System.nanoTime());
+    }
+
+    public void putTemplate(String name, String templateSource, long lastModified) {
+        templates.put(name, new StringTemplateSource(name, templateSource, lastModified));
+    }
+
+    public void removeTemplateSource(String name) {
+        templates.remove(name);
+    }
+
+    public void closeTemplateSource(Object templateSource) {}
+
+    public Object findTemplateSource(String name) {
+        StringTemplateSource stringTemplateSource = templates.get(name);
+        templates.remove(name);
+        return stringTemplateSource;
+    }
+
+    public long getLastModified(Object templateSource) {
+        return ((StringTemplateSource) templateSource).lastModified;
+    }
+
+    public Reader getReader(Object templateSource, String encoding) {
+        return new StringReader(((StringTemplateSource) templateSource).source);
+    }
+
+    @Getter
+    @EqualsAndHashCode(of = "name")
+    public static class StringTemplateSource {
+        private final String name;
+        private final String source;
+        private final long lastModified;
+
+        public StringTemplateSource(String name, String source, long lastModified) {
+            if (name == null) {
+                throw new IllegalArgumentException("name == null");
+            }
+            if (source == null) {
+                throw new IllegalArgumentException("source == null");
+            }
+            if (lastModified < -1L) {
+                throw new IllegalArgumentException("lastModified < -1L");
+            }
+            this.name = name;
+            this.source = source;
+            this.lastModified = lastModified;
+        }
+    }
+}

--- a/src/main/java/com/joutvhu/dynamic/jpa/freemarker/FreemarkerDynamicQueryTemplateHandler.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/freemarker/FreemarkerDynamicQueryTemplateHandler.java
@@ -28,7 +28,6 @@ import java.util.Map;
  * @since 1.0.0
  */
 @NoArgsConstructor
-@Component
 public class FreemarkerDynamicQueryTemplateHandler implements
         DynamicQueryTemplateHandler<Template>, ResourceLoaderAware, InitializingBean {
 

--- a/src/main/java/com/joutvhu/dynamic/jpa/freemarker/FreemarkerDynamicQueryTemplateHandler.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/freemarker/FreemarkerDynamicQueryTemplateHandler.java
@@ -3,7 +3,6 @@ package com.joutvhu.dynamic.jpa.freemarker;
 import com.joutvhu.dynamic.commons.util.DynamicTemplateResolver;
 import com.joutvhu.dynamic.jpa.DynamicQueryTemplate;
 import com.joutvhu.dynamic.jpa.DynamicQueryTemplateHandler;
-import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
 import freemarker.template.Template;
 import lombok.NoArgsConstructor;
@@ -31,15 +30,14 @@ import java.util.Map;
 @NoArgsConstructor
 @Component
 public class FreemarkerDynamicQueryTemplateHandler implements
-        DynamicQueryTemplateHandler<Template>,
-        ResourceLoaderAware,
-        InitializingBean {
+        DynamicQueryTemplateHandler<Template>, ResourceLoaderAware, InitializingBean {
 
     private static final Log log = LogFactory.getLog(FreemarkerDynamicQueryTemplateHandler.class);
 
-    private static StringTemplateLoader sqlTemplateLoader = new StringTemplateLoader();
-    private static Configuration cfg = FreemarkerTemplateConfiguration.instanceWithDefault()
+    private final ConcurrentStringTemplateLoader sqlTemplateLoader = new ConcurrentStringTemplateLoader();
+    private Configuration config = FreemarkerTemplateConfiguration.instanceWithDefault()
             .templateLoader(sqlTemplateLoader)
+            .withoutCache()
             .configuration();
 
     private String encoding = "UTF-8";
@@ -50,7 +48,7 @@ public class FreemarkerDynamicQueryTemplateHandler implements
     @Override
     public DynamicQueryTemplate<Template> createTemplateWithString(String name, String content) {
         try {
-            return new FreemarkerDynamicQueryTemplate(new Template(name, content, cfg));
+            return new FreemarkerDynamicQueryTemplate(new Template(name, content, config));
         } catch (IOException e) {
             e.printStackTrace();
             return null;
@@ -60,7 +58,7 @@ public class FreemarkerDynamicQueryTemplateHandler implements
     @Override
     public DynamicQueryTemplate<Template> findTemplateFile(String name) {
         try {
-            Template template = cfg.getTemplate(name, encoding);
+            Template template = config.getTemplate(name, encoding);
             return new FreemarkerDynamicQueryTemplate(template);
         } catch (IOException e) {
             log.error("Failed finding template: " + name, e);
@@ -74,6 +72,14 @@ public class FreemarkerDynamicQueryTemplateHandler implements
         return FreeMarkerTemplateUtils.processTemplateIntoString(template.getTemplate(), params);
     }
 
+    /**
+     * Setup a custom freemarker custom configuration
+     *
+     * @param configuration to replace the default FreemarkerTemplateConfiguration that uses an StringTemplateLoader
+     */
+    public void setConfiguration(Configuration configuration) {
+        this.config = configuration;
+    }
 
     /**
      * Setup encoding for the process of reading the query template files.

--- a/src/main/java/com/joutvhu/dynamic/jpa/freemarker/FreemarkerTemplateConfiguration.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/freemarker/FreemarkerTemplateConfiguration.java
@@ -3,6 +3,7 @@ package com.joutvhu.dynamic.jpa.freemarker;
 import com.joutvhu.dynamic.jpa.freemarker.directive.SetDirective;
 import com.joutvhu.dynamic.jpa.freemarker.directive.TrimDirective;
 import com.joutvhu.dynamic.jpa.freemarker.directive.WhereDirective;
+import freemarker.cache.NullCacheStorage;
 import freemarker.cache.TemplateLoader;
 import freemarker.template.Configuration;
 
@@ -34,6 +35,13 @@ public class FreemarkerTemplateConfiguration {
         cfg.setSharedVariable("trim", new TrimDirective());
         cfg.setSharedVariable("set", new SetDirective());
         cfg.setSharedVariable("where", new WhereDirective());
+
+        return this;
+    }
+
+    public FreemarkerTemplateConfiguration withoutCache() {
+        cfg.setCacheStorage(NullCacheStorage.INSTANCE);
+        cfg.setTemplateUpdateDelayMilliseconds(0);
 
         return this;
     }

--- a/src/main/java/com/joutvhu/dynamic/jpa/handlebars/HandlebarsDynamicQueryTemplateHandler.java
+++ b/src/main/java/com/joutvhu/dynamic/jpa/handlebars/HandlebarsDynamicQueryTemplateHandler.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ConcurrentHashMap;
  * @since 2.0.0
  */
 @NoArgsConstructor
-@Component
 public class HandlebarsDynamicQueryTemplateHandler implements
         DynamicQueryTemplateHandler<Template>, ResourceLoaderAware, InitializingBean {
 


### PR DESCRIPTION
Added the ability to create freemarker custom configuration and also, in order to make sure that using this library in any kind of environment, even highly concurrent ones has no undesired effects, Freemarker template caching is disabled by default.

Quoting Freemarker page: https://freemarker.apache.org/docs/pgui_misc_multithreading.html

> In a multithreaded environment Configuration instances, Template instances and data-models should be handled as immutable (read-only) objects. That is, you create and initialize them (for example with set... methods), and then you don't modify them later (e.g. you don't call set...). This allows us to avoid expensive synchronized blocks in a multithreaded environment. Beware with Template instances; when you get a Template instance with Configuration.getTemplate, you may get an instance from the template cache that is already used by other threads, so do not call its set... methods (calling process is of course fine).
> 
> The above restrictions do not apply if you access all objects from the same single thread only.
> 
> It is impossible to modify the data-model object or a shared variable with FTL, unless you put methods (or other objects) into the data-model that do that. We discourage you from writing methods that modify the data-model object or the shared variables. Try to use variables that are stored in the environment object instead (this object is created for a single Template.process call to store the runtime state of processing), so you don't modify data that are possibly used by multiple threads. For more information read: Variables, scopes

In order to enable Freemarker template caching you can just provide the required handler bean with the default configuration or define your own configuration with your specific caching needs:

```java
@Bean
public DynamicQueryTemplateHandler dynamicQueryTemplateHandler() {
    DynamicQueryTemplateHandler handler = new DynamicQueryTemplateHandler();
    handler.setConfiguration(FreemarkerTemplateConfiguration.instanceWithDefault().configuration());
    handler.setTemplateLocation("classpath:/query");
    handler.setSuffix(".dsql");
    return handler;
}
```
